### PR TITLE
feat: show droplets in accounts table

### DIFF
--- a/main.js
+++ b/main.js
@@ -423,6 +423,7 @@ function startServer(port, host) {
         if (typeof body.name === 'string') updated.name = body.name;
         if (typeof body.token === 'string') updated.token = body.token;
         if (body.pixelRight != null) updated.pixelRight = body.pixelRight;
+        if (body.droplets != null) updated.droplets = body.droplets;
         if (typeof body.active === 'boolean') updated.active = body.active;
         accounts[idx] = updated;
         writeJson(ACCOUNTS_FILE, accounts);
@@ -470,7 +471,7 @@ function startServer(port, host) {
           return;
         }
         const accounts = readJson(ACCOUNTS_FILE, []);
-        const account = { id: Date.now(), name, token, pixelCount: null, pixelMax: null, active: false };
+        const account = { id: Date.now(), name, token, pixelCount: null, pixelMax: null, droplets: null, active: false };
         
         const settings = readJson(SETTINGS_FILE, { cf_clearance: '' });
         if (settings.cf_clearance && settings.cf_clearance.length >= 30) {
@@ -481,6 +482,7 @@ function startServer(port, host) {
               account.pixelMax = Number(me.charges.max);
               account.active = true;
             }
+            if (me && me.droplets != null) account.droplets = Number(me.droplets);
             if (me && me.name && !name) account.name = String(me.name);
           } catch {}
         }
@@ -523,9 +525,10 @@ function startServer(port, host) {
           } : null
         });
         if (me && me.charges) {
-          
+
           acct.pixelCount = Math.floor(Number(me.charges.count));
           acct.pixelMax = Math.floor(Number(me.charges.max));
+          if (me.droplets != null) acct.droplets = Math.floor(Number(me.droplets));
           acct.active = true;
         } else {
           acct.active = false;

--- a/public/i18n/cn.json
+++ b/public/i18n/cn.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "账户名称",
     "accountToken": "账户令牌",
+    "droplets": "Droplets",
     "pixelRight": "像素上限",
     "status": "状态",
     "actions": "操作",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Kontoname",
     "accountToken": "Konto-Token",
+    "droplets": "Droplets",
     "pixelRight": "Pixellimit",
     "status": "Status",
     "actions": "Aktion",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Account name",
     "accountToken": "Account token",
+    "droplets": "Droplets",
     "pixelRight": "Pixel limit",
     "status": "Status",
     "actions": "Action",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Nombre de la cuenta",
     "accountToken": "Token de la cuenta",
+    "droplets": "Droplets",
     "pixelRight": "Límite de píxeles",
     "status": "Estado",
     "actions": "Acción",

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Nom du compte",
     "accountToken": "Jeton du compte",
+    "droplets": "Droplets",
     "pixelRight": "Limite de pixels",
     "status": "Statut",
     "actions": "Action",

--- a/public/i18n/ja.json
+++ b/public/i18n/ja.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "アカウント名",
     "accountToken": "アカウントトークン",
+    "droplets": "Droplets",
     "pixelRight": "ピクセル上限",
     "status": "ステータス",
     "actions": "操作",

--- a/public/i18n/ru.json
+++ b/public/i18n/ru.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Имя аккаунта",
     "accountToken": "Токен аккаунта",
+    "droplets": "Droplets",
     "pixelRight": "Лимит пикселей",
     "status": "Статус",
     "actions": "Действие",

--- a/public/i18n/tr.json
+++ b/public/i18n/tr.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Hesap ismi",
     "accountToken": "Hesap Tokeni",
+    "droplets": "Droplets",
     "pixelRight": "Piksel Hakkı",
     "status": "Durum",
     "actions": "İşlem",

--- a/public/index.html
+++ b/public/index.html
@@ -644,6 +644,7 @@
                 <tr>
                   <th data-i18n="table.accountName">Hesap ismi</th>
                   <th data-i18n="table.accountToken">Hesap Tokeni</th>
+                  <th data-i18n="table.droplets">Droplets</th>
                   <th data-i18n="table.pixelRight">Piksel Hakkı</th>
                   <th data-i18n="table.status">Durum</th>
                   <th data-i18n="table.actions">İşlem</th>
@@ -3106,6 +3107,10 @@
         const shortToken = fullToken.length > 30 ? (fullToken.slice(0, 30) + '…') : fullToken;
         tdToken.textContent = shortToken;
         tdToken.title = fullToken;
+        const tdDroplets = document.createElement('td');
+        const dropletsRaw = (row.droplets == null ? null : Number(row.droplets));
+        const droplets = (Number.isFinite(dropletsRaw) ? Math.floor(dropletsRaw) : null);
+        tdDroplets.textContent = droplets == null ? '-' : String(droplets);
         const tdPixel = document.createElement('td');
         const countRaw = (row.pixelCount == null ? null : Number(row.pixelCount));
         const maxRaw = (row.pixelMax == null ? null : Number(row.pixelMax));
@@ -3159,6 +3164,7 @@
         tdActions.appendChild(actionsWrap);
         tr.appendChild(tdName);
         tr.appendChild(tdToken);
+        tr.appendChild(tdDroplets);
         tr.appendChild(tdPixel);
         tr.appendChild(tdStatus);
         tr.appendChild(tdActions);


### PR DESCRIPTION
## Summary
- display droplets in account table and read from API
- include droplets in server account data
- add droplets translations for all languages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
