### PR TITLE
Restore canvas palette layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -657,14 +657,14 @@
       border-radius: 12px;
       backdrop-filter: blur(6px);
       padding: 8px;
-      display: grid;
-      grid-template-columns: repeat(6, 18px);
+      display: flex;
+      flex-wrap: wrap;
       gap: 6px;
       align-items: center;
       justify-content: center;
-      width: fit-content;
       z-index: 1001;
       box-shadow: 0 8px 30px rgba(0,0,0,0.35);
+      max-width: min(95vw, 720px);
     }
     /* Premium/Free switcher next to palette (toggle style) */
     .palette-mode-wrap { position: fixed; z-index: 1002; display: inline-flex; align-items: center; gap: 10px; pointer-events: auto; padding: 6px 10px; border-radius: 12px; background: rgba(17, 20, 24, 0.85); border: 1px solid rgba(255,255,255,0.1); box-shadow: 0 8px 30px rgba(0,0,0,0.35); backdrop-filter: blur(6px); }


### PR DESCRIPTION
## Summary
- Fix canvas color palette to use flex layout and wrap like in earlier commit

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a62556d1bc8320b61ff764b5c6e7bc