### PR TITLE
refactor: centralize single tile loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1361,6 +1361,7 @@
     const mosaicUse4 = document.getElementById('mosaic-use4');
     const mosaicFetch = document.getElementById('mosaic-fetch');
     const mosaicCanvas = document.createElement('canvas');
+    const singleCanvas = document.createElement('canvas');
     const sidebar = document.getElementById('sidebar');
     const thumbList = document.getElementById('thumb-list');
     const counter = document.getElementById('counter');
@@ -2943,6 +2944,7 @@
 
     let img = null;
     let baseImageData = null;
+    const pendingPaints = new Map();
     let currentTiles = [];
     let currentTileW = 0;
     let currentTileH = 0;
@@ -3143,7 +3145,10 @@ async function loadSingleTile(area, no, preserveView = false) {
     imgEl.onerror = reject;
     imgEl.src = url;
   });
-  img = image;
+  singleCanvas.width = image.width;
+  singleCanvas.height = image.height;
+  singleCanvas.getContext('2d').drawImage(image, 0, 0);
+  img = singleCanvas;
   baseImageData = null;
   currentTiles = [{ x: Number(area), y: Number(no) }];
   currentTileW = image.width;
@@ -3151,6 +3156,7 @@ async function loadSingleTile(area, no, preserveView = false) {
   currentMosaicCols = 1;
   currentMosaicRows = 1;
   try { signItems.forEach(it => { if (it) it._placedCountCache = null; }); } catch {}
+  reapplyPendingPaints(area, no);
   if (preserveView) {
     render();
   } else {
@@ -4948,6 +4954,7 @@ function loadImage(area, no, preserveView = false) {
         // Clear cached placed counts so auto-mode uses fresh data
         signItems.forEach(it => { if (it) it._placedCountCache = null; });
       } catch {}
+      coords.forEach(c => reapplyPendingPaints(c.x, c.y));
       if (preserveView) {
         render();
       } else {
@@ -5863,7 +5870,7 @@ function loadImage(area, no, preserveView = false) {
       return rows;
     }
 
-    async function postBatch(area, no, colors, coords, t, jToken) {
+async function postBatch(area, no, colors, coords, t, jToken) {
       try {
         const res = await fetch('/api/pixel/' + encodeURIComponent(area) + '/' + encodeURIComponent(no), {
           method: 'POST',
@@ -5878,6 +5885,40 @@ function loadImage(area, no, preserveView = false) {
       } catch (e) {
         return { ok: false, error: e && e.message ? e.message : String(e) };
       }
+}
+
+    function recordPendingPaints(colors, coords, area, no) {
+      const key = String(area) + ',' + String(no);
+      let rec = pendingPaints.get(key);
+      if (!rec) {
+        rec = { colors: [], coords: [] };
+        pendingPaints.set(key, rec);
+      }
+      rec.colors.push(...colors);
+      rec.coords.push(...coords);
+    }
+
+    function reapplyPendingPaints(area, no) {
+      const key = String(area) + ',' + String(no);
+      const rec = pendingPaints.get(key);
+      if (!rec) return;
+      applyPaintedPixels(rec.colors, rec.coords, area, no);
+      const id = ensureBaseImageData();
+      let allGood = true;
+      if (id) {
+        for (let i = 0; i < rec.colors.length; i++) {
+          const cx = Math.round(rec.coords[i * 2] || 0);
+          const cy = Math.round(rec.coords[i * 2 + 1] || 0);
+          if (cx < 0 || cy < 0 || cx >= id.width || cy >= id.height) continue;
+          const index = ((id.width * cy + cx) << 2);
+          const rgb = getPaletteRgbById(rec.colors[i]);
+          if (id.data[index] !== rgb[0] || id.data[index + 1] !== rgb[1] || id.data[index + 2] !== rgb[2] || id.data[index + 3] !== 255) {
+            allGood = false;
+            break;
+          }
+        }
+      }
+      if (allGood) pendingPaints.delete(key);
     }
 
     function applyPaintedPixels(colors, coords, area, no) {
@@ -5893,6 +5934,7 @@ function loadImage(area, no, preserveView = false) {
         offsetY = row * (currentTileH || 0);
       }
       let changed = false;
+      const ctx = img && img.getContext ? img.getContext('2d') : null;
       for (let i = 0; i < colors.length; i++) {
         const cx = Math.round(coords[i * 2] || 0) + offsetX;
         const cy = Math.round(coords[i * 2 + 1] || 0) + offsetY;
@@ -5902,12 +5944,17 @@ function loadImage(area, no, preserveView = false) {
         if (c == null || c === 0) {
           id.data[index] = id.data[index+1] = id.data[index+2] = 0;
           id.data[index+3] = 0;
+          if (ctx) ctx.clearRect(cx, cy, 1, 1);
         } else {
           const rgb = getPaletteRgbById(c);
           id.data[index] = rgb[0];
           id.data[index+1] = rgb[1];
           id.data[index+2] = rgb[2];
           id.data[index+3] = 255;
+          if (ctx) {
+            ctx.fillStyle = 'rgb(' + rgb[0] + ',' + rgb[1] + ',' + rgb[2] + ')';
+            ctx.fillRect(cx, cy, 1, 1);
+          }
         }
         const key = String(cx) + ',' + String(cy);
         if (readyGlobalSelected && readyGlobalSelected.delete(key)) changed = true;
@@ -6014,7 +6061,10 @@ if (currentTiles && currentTiles.length > 1) {
             break;
           }
         }
-        if (r.ok) applyPaintedPixels(colorsSlice, coordsSlice, g.area, g.no);
+        if (r.ok) {
+          applyPaintedPixels(colorsSlice, coordsSlice, g.area, g.no);
+          recordPendingPaints(colorsSlice, coordsSlice, g.area, g.no);
+        }
         offset += take;
         usedIds.push(acc.id);
         try { await refreshAccountById(acc.id); } catch {}
@@ -6112,7 +6162,10 @@ if (currentTiles && currentTiles.length > 1) {
               break;
             }
           }
-          if (r.ok) applyPaintedPixels(colorsSlice, coordsSlice, area, no);
+          if (r.ok) {
+            applyPaintedPixels(colorsSlice, coordsSlice, area, no);
+            recordPendingPaints(colorsSlice, coordsSlice, area, no);
+          }
           usedIds.push(acc.id);
           assignedCount += colorsSlice.length;
           try { await refreshAccountById(acc.id); } catch {}

--- a/public/index.html
+++ b/public/index.html
@@ -5892,6 +5892,7 @@ function loadImage(area, no, preserveView = false) {
         offsetX = col * (currentTileW || 0);
         offsetY = row * (currentTileH || 0);
       }
+      let changed = false;
       for (let i = 0; i < colors.length; i++) {
         const cx = Math.round(coords[i * 2] || 0) + offsetX;
         const cy = Math.round(coords[i * 2 + 1] || 0) + offsetY;
@@ -5908,6 +5909,21 @@ function loadImage(area, no, preserveView = false) {
           id.data[index+2] = rgb[2];
           id.data[index+3] = 255;
         }
+        const key = String(cx) + ',' + String(cy);
+        if (readyGlobalSelected && readyGlobalSelected.delete(key)) changed = true;
+        for (let j = 0; j < signItems.length; j++) {
+          const it = signItems[j];
+          if (!it) continue;
+          const map = getSelectedMap(it);
+          if (!map || map.size === 0) continue;
+          const lx = cx - (it.worldX || 0);
+          const ly = cy - (it.worldY || 0);
+          if (map.delete(keyFor(lx, ly))) changed = true;
+        }
+      }
+      if (changed) {
+        drawSelectionOverlay();
+        try { updatePixelMarkers(); updateReadySelectionLabel(); updateStartEnabled(); } catch {}
       }
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -1801,6 +1801,25 @@
     let readyMouseMoved = false;
     let autoSelectDeleteMode = false;
     const READY_CLICK_MOVE_TOLERANCE = 4;
+
+    let isPainting = false;
+    let paintingTimeout = null;
+    let missedCanvasReload = false;
+    function markPainting() {
+      isPainting = true;
+      if (paintingTimeout) clearTimeout(paintingTimeout);
+      paintingTimeout = setTimeout(() => {
+        resetPaintingFlag();
+      }, 30 * 1000);
+    }
+    function resetPaintingFlag() {
+      isPainting = false;
+      if (paintingTimeout) { clearTimeout(paintingTimeout); paintingTimeout = null; }
+      if (missedCanvasReload) {
+        missedCanvasReload = false;
+        try { reloadCurrentBackground(); } catch {}
+      }
+    }
     function getPaletteRgbById(id){
       const arr = (ACTIVE_PALETTE && Array.isArray(ACTIVE_PALETTE)) ? ACTIVE_PALETTE : PALETTE;
       for (let i = 0; i < arr.length; i++) { if (arr[i].id === id) return arr[i].rgb; }
@@ -3096,6 +3115,10 @@
     }
 
 async function reloadCurrentBackground() {
+  if (isPainting) {
+    missedCanvasReload = true;
+    return false;
+  }
   try {
     const saved = JSON.parse(localStorage.getItem('lastFetch') || 'null');
     if (saved) {
@@ -4730,7 +4753,13 @@ function loadImage(area, no, preserveView = false) {
         }
       } catch {}
       try { await loadAccounts(); } catch {}
-      try { reloadCurrentBackground(); } catch {}
+      try {
+        if (!isPainting) {
+          reloadCurrentBackground();
+        } else {
+          missedCanvasReload = true;
+        }
+      } catch {}
       finally {
         lastBulkRefreshAt = Date.now();
         bulkRefreshInFlight = false;
@@ -5625,6 +5654,7 @@ function loadImage(area, no, preserveView = false) {
 
     function resetReadyNow(){
       try { if (readyPopup) readyPopup.hidden = true; } catch {}
+      resetPaintingFlag();
       try {
         if (readyLockedItem) { readyLockedItem.lockedByReady = false; updateItemLockUi(readyLockedItem); readyLockedItem = null; }
       } catch {}
@@ -5683,6 +5713,7 @@ function loadImage(area, no, preserveView = false) {
           // Always close movement popup when toggling Ready
           try { if (movementPopup) movementPopup.hidden = true; } catch {}
           readyPopup.hidden = !readyPopup.hidden;
+          if (readyPopup.hidden) { resetPaintingFlag(); }
           
           try {
             if (!readyPopup.hidden) {
@@ -6028,81 +6059,91 @@ if (startBtn) {
 if (currentTiles && currentTiles.length > 1) {
   const groups = groupPixelsByTile(data.colors, data.coords);
   (async () => {
-    let paintedAny = false;
-    let missingTotal = 0;
-    let usedIds = []; 
-    let hadRequestError = false;
-    let didReload = false;
-    for (const g of groups) {
-      const total = g.colors.length|0;
-      const selectedAccounts = getSelectedAccountsSortedByCapacityDesc();
-      let offset = 0;
-      for (let i = 0; i < selectedAccounts.length && offset < total; i++) {
-        const acc = selectedAccounts[i];
-        const cap = Math.max(0, Math.floor(Number(acc.pixelCount) || 0));
-        if (cap <= 0) continue;
-        const take = Math.min(cap, total - offset);
-        if (take <= 0) continue;
-        const colorsSlice = g.colors.slice(offset, offset + take);
-        const coordsSlice = g.coords.slice(offset * 2, (offset + take) * 2);
-        const r = await postBatch(String(g.area), String(g.no), colorsSlice, coordsSlice, authToken, String(acc.token || ''));
-        if (r && r.status === 429) {
-          hadRequestError = true;
-          try { showToast(t('messages.cfClearanceChange'), 'error', 3500); } catch { showToast('Please change cf_clearance.', 'error', 3500); }
-          break;
-        }
-        if (!r.ok) {
-          if (r.status >= 500) {
-            try { await loadAccounts(); } catch {}
-            continue;
-          } else {
+    markPainting();
+    try {
+      let paintedAny = false;
+      let missingTotal = 0;
+      let usedIds = [];
+      let hadRequestError = false;
+      let didReload = false;
+      for (const g of groups) {
+        const total = g.colors.length|0;
+        const selectedAccounts = getSelectedAccountsSortedByCapacityDesc();
+        let offset = 0;
+        for (let i = 0; i < selectedAccounts.length && offset < total; i++) {
+          const acc = selectedAccounts[i];
+          const cap = Math.max(0, Math.floor(Number(acc.pixelCount) || 0));
+          if (cap <= 0) continue;
+          const take = Math.min(cap, total - offset);
+          if (take <= 0) continue;
+          const colorsSlice = g.colors.slice(offset, offset + take);
+          const coordsSlice = g.coords.slice(offset * 2, (offset + take) * 2);
+          const r = await postBatch(String(g.area), String(g.no), colorsSlice, coordsSlice, authToken, String(acc.token || ''));
+          if (r && r.status === 429) {
             hadRequestError = true;
-            showToast(r.payload ? JSON.stringify(r.payload) : (r.text || r.error || t('messages.errorGeneric')), 'error', 3000);
+            try { showToast(t('messages.cfClearanceChange'), 'error', 3500); } catch { showToast('Please change cf_clearance.', 'error', 3500); }
             break;
           }
+          if (!r.ok) {
+            if (r.status >= 500) {
+              try { await loadAccounts(); } catch {}
+              continue;
+            } else {
+              hadRequestError = true;
+              showToast(r.payload ? JSON.stringify(r.payload) : (r.text || r.error || t('messages.errorGeneric')), 'error', 3000);
+              break;
+            }
+          }
+          if (r.ok) {
+            applyPaintedPixels(colorsSlice, coordsSlice, g.area, g.no);
+            recordPendingPaints(colorsSlice, coordsSlice, g.area, g.no);
+          }
+          offset += take;
+          usedIds.push(acc.id);
+          try { await refreshAccountById(acc.id); } catch {}
         }
-        if (r.ok) {
-          applyPaintedPixels(colorsSlice, coordsSlice, g.area, g.no);
-          recordPendingPaints(colorsSlice, coordsSlice, g.area, g.no);
+        if (offset > 0) paintedAny = true;
+        if (offset < total && !hadRequestError) missingTotal += (total - offset);
+      }
+      if (paintedAny) {
+        showToast(t('messages.painted'), 'success', 1800);
+        if (!isPainting) {
+          didReload = await reloadCurrentBackground();
+        } else {
+          missedCanvasReload = true;
+          didReload = false;
         }
-        offset += take;
-        usedIds.push(acc.id);
-        try { await refreshAccountById(acc.id); } catch {}
+        try { clearAllReadySelections(); } catch {}
+        try { readyGlobalMode = false; } catch {}
+        if (!autoMode) {
+          try { resetReadyNow(); } catch {}
+        }
+        try { updateStartEnabled(); } catch {}
       }
-      if (offset > 0) paintedAny = true;
-      if (offset < total && !hadRequestError) missingTotal += (total - offset);
-    }
-    if (paintedAny) {
-      showToast(t('messages.painted'), 'success', 1800);
-      didReload = await reloadCurrentBackground();
-      try { clearAllReadySelections(); } catch {}
-      try { readyGlobalMode = false; } catch {}
-      if (!autoMode) {
-        try { resetReadyNow(); } catch {}
+      if (missingTotal > 0) {
+        showToast(t('messages.insufficientPixelPower', { n: missingTotal }), 'error', 3000);
       }
-      try { updateStartEnabled(); } catch {}
-    }
-    if (missingTotal > 0) {
-      showToast(t('messages.insufficientPixelPower', { n: missingTotal }), 'error', 3000);
-    }
-    try { await loadAccounts(); } catch {}
-    try { updateReadySelectionLabel(); } catch {}
-    render();
-    // Auto mode: después de pintar, selecciona la siguiente cuenta y auto selecciona píxeles
-    if (autoMode && paintedAny && !hadRequestError) {
-      try {
-        await loadAccounts();
-        try { renderReadyAccountList(); } catch {}
-        updateReadyPixelForSelectedAccounts();
-        const nextId = pickNextBestAccountId(usedIds); 
-        if (nextId != null) {
-          readySelectedAccountIds = [nextId];
+      try { await loadAccounts(); } catch {}
+      try { updateReadySelectionLabel(); } catch {}
+      render();
+      // Auto mode: después de pintar, selecciona la siguiente cuenta y auto selecciona píxeles
+      if (autoMode && paintedAny && !hadRequestError) {
+        try {
+          await loadAccounts();
           try { renderReadyAccountList(); } catch {}
           updateReadyPixelForSelectedAccounts();
-          try { await new Promise(resolve => setTimeout(resolve, didReload ? 50 : 300)); } catch {}
-          if (autoSelectBtn) { autoSelectDeleteMode = false; autoSelectBtn.click(); }
-        }
-      } catch {}
+          const nextId = pickNextBestAccountId(usedIds);
+          if (nextId != null) {
+            readySelectedAccountIds = [nextId];
+            try { renderReadyAccountList(); } catch {}
+            updateReadyPixelForSelectedAccounts();
+            try { await new Promise(resolve => setTimeout(resolve, didReload ? 50 : 300)); } catch {}
+            if (autoSelectBtn) { autoSelectDeleteMode = false; autoSelectBtn.click(); }
+          }
+        } catch {}
+      }
+    } finally {
+      resetPaintingFlag();
     }
   })();
 } else {
@@ -6120,11 +6161,13 @@ if (currentTiles && currentTiles.length > 1) {
       }
       const assigned = new Array(tasks.length).fill(false);
       (async () => {
-        let assignedCount = 0;
-        const usedIds = [];
-        let hadRequestError = false;
-        let didReload = false;
-        for (let i = 0; i < selectedAccounts.length && assignedCount < total; i++) {
+        markPainting();
+        try {
+          let assignedCount = 0;
+          const usedIds = [];
+          let hadRequestError = false;
+          let didReload = false;
+          for (let i = 0; i < selectedAccounts.length && assignedCount < total; i++) {
           const acc = selectedAccounts[i];
           const cap = Math.max(0, Math.floor(Number(acc.pixelCount) || 0));
           if (cap <= 0) continue;
@@ -6170,23 +6213,28 @@ if (currentTiles && currentTiles.length > 1) {
           assignedCount += colorsSlice.length;
           try { await refreshAccountById(acc.id); } catch {}
         }
-        if (assignedCount > 0) {
-          showToast(t('messages.painted'), 'success', 1800);
-          didReload = await reloadCurrentBackground();
-          try { clearAllReadySelections(); } catch {}
-          try { readyGlobalMode = false; } catch {}
-          if (!autoMode) {
-            try { resetReadyNow(); } catch {}
+          if (assignedCount > 0) {
+            showToast(t('messages.painted'), 'success', 1800);
+            if (!isPainting) {
+              didReload = await reloadCurrentBackground();
+            } else {
+              missedCanvasReload = true;
+              didReload = false;
+            }
+            try { clearAllReadySelections(); } catch {}
+            try { readyGlobalMode = false; } catch {}
+            if (!autoMode) {
+              try { resetReadyNow(); } catch {}
+            }
+            try { updateStartEnabled(); } catch {}
           }
-          try { updateStartEnabled(); } catch {}
-        }
-        if (assignedCount < total && !hadRequestError) {
-          showToast(t('messages.insufficientPixelPower', { n: (total - assignedCount) }), 'error', 3000);
-        }
-        try { await loadAccounts(); } catch {}
-        try { updateReadySelectionLabel(); } catch {}
-        render();
-        // Auto mode: después de pintar, selecciona la siguiente cuenta y auto selecciona píxeles
+          if (assignedCount < total && !hadRequestError) {
+            showToast(t('messages.insufficientPixelPower', { n: (total - assignedCount) }), 'error', 3000);
+          }
+          try { await loadAccounts(); } catch {}
+          try { updateReadySelectionLabel(); } catch {}
+          render();
+          // Auto mode: después de pintar, selecciona la siguiente cuenta y auto selecciona píxeles
 if (autoMode && assignedCount > 0 && !hadRequestError) {
   try {
     await loadAccounts();
@@ -6202,6 +6250,9 @@ if (autoMode && assignedCount > 0 && !hadRequestError) {
     }
   } catch {}
 }
+        } finally {
+          resetPaintingFlag();
+        }
       })();
     }
   });
@@ -6407,6 +6458,7 @@ if (autoMode && assignedCount > 0 && !hadRequestError) {
 
     const CANVAS_REFRESH_MS = 30 * 1000;
     setInterval(() => {
+      if (isPainting) { missedCanvasReload = true; return; }
       try {
         const saved = JSON.parse(localStorage.getItem('lastFetch') || 'null');
         if (!saved) return;

--- a/public/index.html
+++ b/public/index.html
@@ -3093,65 +3093,27 @@
       render();
     }
 
- async function reloadCurrentBackground() {
+async function reloadCurrentBackground() {
   try {
     const saved = JSON.parse(localStorage.getItem('lastFetch') || 'null');
     if (saved) {
       if (saved.mode === 'mosaic') {
-        try {
-          await loadMosaic(saved.coords, true);
-          return true;
-        } catch {
-          return false;
-        }
+        await loadMosaic(saved.coords, true);
+        return true;
       }
       if (saved.mode === 'single') {
         const area = saved.coords[0].x;
         const no = saved.coords[0].y;
-        return await new Promise(resolve => {
-          const url = buildUrl(area, no) + '?t=' + Date.now();
-          const image = new Image();
-          image.onload = () => {
-            img = image;
-            baseImageData = null;
-            currentTiles = [{ x: Number(area), y: Number(no) }];
-            currentTileW = image.width;
-            currentTileH = image.height;
-            currentMosaicCols = 1;
-            currentMosaicRows = 1;
-            try { signItems.forEach(it => { if (it) it._placedCountCache = null; }); } catch {}
-            render();
-            updatePixelMarkers();
-            resolve(true);
-          };
-          image.onerror = () => resolve(false);
-          image.src = url;
-        });
+        await loadSingleTile(area, no, true);
+        return true;
       }
+      return false;
     }
-    // Si no hay datos guardados, carga desde los inputs
     const area = (areaInput && areaInput.value) ? String(areaInput.value).trim() : '';
     const no = (noInput && noInput.value) ? String(noInput.value).trim() : '';
     if (!area || !no) return false;
-    return await new Promise(resolve => {
-      const url = buildUrl(area, no) + '?t=' + Date.now();
-      const image = new Image();
-      image.onload = () => {
-        img = image;
-        baseImageData = null;
-        currentTiles = [{ x: Number(area), y: Number(no) }];
-        currentTileW = image.width;
-        currentTileH = image.height;
-        currentMosaicCols = 1;
-        currentMosaicRows = 1;
-        try { signItems.forEach(it => { if (it) it._placedCountCache = null; }); } catch {}
-        render();
-        updatePixelMarkers();
-        resolve(true);
-      };
-      image.onerror = () => resolve(false);
-      image.src = url;
-    });
+    await loadSingleTile(area, no, true);
+    return true;
   } catch {
     return false;
   }
@@ -3173,40 +3135,38 @@ function hasSavedView(){
   } catch { return false; }
 }
 
+async function loadSingleTile(area, no, preserveView = false) {
+  const url = buildUrl(area, no) + '?t=' + Date.now();
+  const image = await new Promise((resolve, reject) => {
+    const imgEl = new Image();
+    imgEl.onload = () => resolve(imgEl);
+    imgEl.onerror = reject;
+    imgEl.src = url;
+  });
+  img = image;
+  baseImageData = null;
+  currentTiles = [{ x: Number(area), y: Number(no) }];
+  currentTileW = image.width;
+  currentTileH = image.height;
+  currentMosaicCols = 1;
+  currentMosaicRows = 1;
+  try { signItems.forEach(it => { if (it) it._placedCountCache = null; }); } catch {}
+  if (preserveView) {
+    render();
+  } else {
+    fitToView();
+  }
+  try { updatePixelMarkers(); } catch {}
+}
+
 function loadImage(area, no, preserveView = false) {
-  const url = buildUrl(area, no);
-  const image = new Image();
-
-  image.onload = () => {
-    const prevScale = state.scale;
-    const prevTx = state.translateX;
-    const prevTy = state.translateY;
-
-    img = image;
-    currentTiles = [{ x: Number(area), y: Number(no) }];
-    currentTileW = image.width;
-    currentTileH = image.height;
-    currentMosaicCols = 1;
-    currentMosaicRows = 1;
-    try { baseImageData = null; } catch {}
-
-    if (preserveView) {
-      state.scale = prevScale;
-      state.translateX = prevTx;
-      state.translateY = prevTy;
-      render();
-    } else if (hasSavedView()) {
-      render();
-      updatePixelMarkers();
-    } else {
-      fitToView();
-    }
-    localStorage.setItem('lastFetch', JSON.stringify({ mode: 'single', coords: [{ x: Number(area), y: Number(no) }] }));
-  };
-  image.onerror = () => {
-    alert(t('messages.imageLoadFailed'));
-  };
-  image.src = url;
+  loadSingleTile(area, no, preserveView || hasSavedView())
+    .then(() => {
+      localStorage.setItem('lastFetch', JSON.stringify({ mode: 'single', coords: [{ x: Number(area), y: Number(no) }] }));
+    })
+    .catch(() => {
+      alert(t('messages.imageLoadFailed'));
+    });
 }
     let rightEraseHeld = false;
     let rightEraseLastKey = null;
@@ -5913,10 +5873,41 @@ function loadImage(area, no, preserveView = false) {
         const text = await res.text();
         let payload = null;
         try { payload = JSON.parse(text); } catch {}
-        
+
         return { ok: res.status < 500 && !!(payload && Object.prototype.hasOwnProperty.call(payload, 'painted')), payload, text, status: res.status };
       } catch (e) {
         return { ok: false, error: e && e.message ? e.message : String(e) };
+      }
+    }
+
+    function applyPaintedPixels(colors, coords, area, no) {
+      const id = ensureBaseImageData();
+      if (!id) return;
+      let offsetX = 0, offsetY = 0;
+      const idx = currentTiles ? currentTiles.findIndex(t => t && t.x === Number(area) && t.y === Number(no)) : -1;
+      if (idx >= 0) {
+        const cols = currentMosaicCols || 1;
+        const col = idx % cols;
+        const row = Math.floor(idx / cols);
+        offsetX = col * (currentTileW || 0);
+        offsetY = row * (currentTileH || 0);
+      }
+      for (let i = 0; i < colors.length; i++) {
+        const cx = Math.round(coords[i * 2] || 0) + offsetX;
+        const cy = Math.round(coords[i * 2 + 1] || 0) + offsetY;
+        if (cx < 0 || cy < 0 || cx >= id.width || cy >= id.height) continue;
+        const index = ((id.width * cy + cx) << 2);
+        const c = colors[i];
+        if (c == null || c === 0) {
+          id.data[index] = id.data[index+1] = id.data[index+2] = 0;
+          id.data[index+3] = 0;
+        } else {
+          const rgb = getPaletteRgbById(c);
+          id.data[index] = rgb[0];
+          id.data[index+1] = rgb[1];
+          id.data[index+2] = rgb[2];
+          id.data[index+3] = 255;
+        }
       }
     }
 
@@ -6007,8 +5998,9 @@ if (currentTiles && currentTiles.length > 1) {
             break;
           }
         }
+        if (r.ok) applyPaintedPixels(colorsSlice, coordsSlice, g.area, g.no);
         offset += take;
-        usedIds.push(acc.id); 
+        usedIds.push(acc.id);
         try { await refreshAccountById(acc.id); } catch {}
       }
       if (offset > 0) paintedAny = true;
@@ -6104,6 +6096,7 @@ if (currentTiles && currentTiles.length > 1) {
               break;
             }
           }
+          if (r.ok) applyPaintedPixels(colorsSlice, coordsSlice, area, no);
           usedIds.push(acc.id);
           assignedCount += colorsSlice.length;
           try { await refreshAccountById(acc.id); } catch {}
@@ -6329,10 +6322,10 @@ if (autoMode && assignedCount > 0 && !hadRequestError) {
     } else if (saved && saved.mode === 'single') {
       areaInput.value = String(saved.coords[0].x);
       noInput.value = String(saved.coords[0].y);
-      loadImage(areaInput.value, noInput.value);
+      loadSingleTile(areaInput.value, noInput.value, true);
     } else if (areaInput.value && noInput.value) {
       loadImage(areaInput.value, noInput.value);
-    }    
+    }
   } catch {}
   updateCounter();
   loadAccounts();
@@ -6351,7 +6344,7 @@ if (autoMode && assignedCount > 0 && !hadRequestError) {
         if (saved.mode === 'mosaic') {
           loadMosaic(saved.coords, true);
         } else if (saved.mode === 'single') {
-          loadImage(saved.coords[0].x, saved.coords[0].y, true);
+          loadSingleTile(saved.coords[0].x, saved.coords[0].y, true);
         }
       } catch {}
     }, CANVAS_REFRESH_MS);


### PR DESCRIPTION
## Summary
- add `loadSingleTile` helper to load and render a single tile
- simplify `reloadCurrentBackground` into dispatcher for mosaic vs single
- update initialization and refresh loops to use the new helper
- track painted pixels locally so slow fetches don't cause duplicate painting

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7f982e20c8320ac62fe8a6965ccf7